### PR TITLE
Add check to 'ref', print payload, update log level to INFO

### DIFF
--- a/client-umb/Dockerfile
+++ b/client-umb/Dockerfile
@@ -1,10 +1,18 @@
 FROM centos/python-36-centos7
+
 WORKDIR /opt/app
+
+ENV LOG_LEVEL "INFO"
+
+ENV GH_BRANCH ""
+ENV URL_TRIGGER ""
+ENV WS_SERVER "ws://ws-server-nos-perf.apps.us-west-2.online-starter.openshift.com/ws"
 ENV RH_CERT "/opt/app/certs/ca-bundle.crt"
 ENV RH_KEY "/opt/app/certs/msg-tightbeam.key.pem"
 ENV RH_CRT "/opt/app/certs/msg-tightbeam.crt.pem"
 ENV AMQP_URL "amqps://messaging-devops-broker01.dev1.ext.devlab.redhat.com:5671"
 ENV AMQP_TOPIC "test"
+
 USER root
 ADD . .
 RUN	pip install -r requirements.txt


### PR DESCRIPTION
Mainly I do a check for 'ref' and allow the script to ignore it if not exists. So that the client won't throw Error and quit. I also change the logs to INFO, and print payload so that we can check/digest it for different event body. 
In the future, we might need to allow other events to pass-through, e.g., the "comment" event. But at this moment, we can just leave out other event types. 